### PR TITLE
Add Swift Code Generator

### DIFF
--- a/Swift5_2.js
+++ b/Swift5_2.js
@@ -1,0 +1,111 @@
+class Swift5_2 extends PureComponent {
+
+  //
+  // Proptypes
+
+  static propTypes = {
+    regex: PropTypes.string.isRequired,
+    flags: PropTypes.string.isRequired,
+    delimiter: PropTypes.string.isRequired,
+    testString: PropTypes.string.isRequired,
+    isSubstituting: PropTypes.bool.isRequired,
+    isGlobal: PropTypes.bool.isRequired,
+    substString: PropTypes.string
+  };
+
+  //
+  // Control
+
+  _escapeSwiftString(input) {
+    // Simple search for a line break
+    let isMultiline = input.match(/\n/g)
+    // Wrap the string literal around # for each # found in the input string, plus 1 extra #
+    var hashes = "#"
+    while (input.search("#") != -1) {
+      hashes += "#"
+    }
+
+    var result = hashes
+    if (isMultiline) {
+      result += "\"\"\"\n"
+    } else {
+      result += "\""
+    }
+    result += input
+    if (isMultiline) {
+      result += "\n\"\"\""
+    } else {
+      result += "\""
+    }
+    result += hashes
+
+    return result
+  }
+
+  //
+  // Render functions
+
+  render() {
+    return (
+      <Highlight lang="swift">
+        {this._renderCode()}
+      </Highlight>
+    );
+  }
+
+  _renderCode() {
+    const { regex, flags, delimiter, testString, isSubstituting, substString, isGlobal } = this.props;
+
+    const codeString = new CodeString();
+    const includesXFlag = flags.includes("x");
+
+    // Generate code string
+    codeString.append(`import Foundation`)
+    codeString.append()
+    codeString.append(`let pattern = ${this._escapeSwiftString(regex.toString())}`)
+    codeString.append(`let regex = try! NSRegularExpression(pattern: pattern, options: ` + (includesXFlag ? `.anchorsMatchLines` : `[]`) + `)`)
+    codeString.append(`let testString = ${this._escapeSwiftString(testString)}`)
+    codeString.append(`let stringRange = NSRange(location: 0, length: testString.utf16.count)`)
+
+    if (isSubstituting) {
+      codeString.append(`let substitutionString = ${this._escapeSwiftString(substString)}`)
+      if (isGlobal) {
+        codeString.append(`let result = regex.stringByReplacingMatches(in: testString, range: stringRange, withTemplate: substitutionString)`)
+        codeString.append(`print(result)`)
+      } else {
+        codeString.append(`let lookupRange = (testString as NSString).range(of: pattern, options: .regularExpression, range: stringRange)`)
+        codeString.append(`if lookupRange.intersection(stringRange) != nil {`, 4)
+        codeString.append(`let result = regex.stringByReplacingMatches(in: testString, range: lookupRange, withTemplate: substitutionString)`)
+        codeString.append(`print(result)`, 0)
+        codeString.append(`} else {`, 4)
+        codeString.append(`print("No matches were found.")`, 0)
+        codeString.append(`}`)
+      }
+    } else {
+        if (isGlobal) {
+          codeString.append(`let matches = regex.matches(in: testString, range: stringRange)`)
+          codeString.append(`var result: [[String]] = []`)
+          codeString.append(`for match in matches {`, 4)
+          codeString.append(`var groups: [String] = []`)
+          codeString.append(`for rangeIndex in 1 ..< match.numberOfRanges {`, 8)
+          codeString.append(`groups.append((testString as NSString).substring(with: match.range(at: rangeIndex)))`, 4)
+          codeString.append(`}`)
+          codeString.append(`if !groups.isEmpty {`, 8)
+          codeString.append(`result.append(groups)`, 4)
+          codeString.append(`}`, 0)
+          codeString.append(`}`)
+          codeString.append(`print(result)`)
+        } else {
+          codeString.append(`if let firstMatch = regex.firstMatch(in: testString, range: stringRange) {`, 4)
+          codeString.append(`let result: [String] = (1 ..< firstMatch.numberOfRanges).map { (testString as NSString).substring(with: firstMatch.range(at: $0)) }`)
+          codeString.append(`print(result)`, 0)
+          codeString.append(`} else {`, 4)
+          codeString.append(`print("No matches were found.")`, 0)
+          codeString.append(`}`)
+        }
+    }
+    return codeString.toString()
+  }
+}
+
+export default Swift5_2;

--- a/Swift5_2.js
+++ b/Swift5_2.js
@@ -42,6 +42,18 @@ class Swift5_2 extends PureComponent {
     return result
   }
 
+  // Removes the value from the given array, if existent, and return whether a value was removed.
+  // Requires the first argument to be an instance of array.
+  _removeValueFromArray(array, value) {
+    let indexOfValue = array.indexOf(value)
+    if (indexOfValue > -1) {
+      array.splice(indexOfValue, 1)
+      return true
+    } else {
+      return false
+    }
+  }
+
   //
   // Render functions
 
@@ -56,14 +68,37 @@ class Swift5_2 extends PureComponent {
   _renderCode() {
     const { regex, flags, delimiter, testString, isSubstituting, substString, isGlobal } = this.props;
 
-    const codeString = new CodeString();
-    const includesXFlag = flags.includes("x");
+    const codeString = new CodeString()
+
+    var options = []
+    this._removeValueFromArray(flags, "g")
+    if (this._removeValueFromArray(flags, "m")) {
+      options.push(".anchorsMatchLines")
+    }
+    if (this._removeValueFromArray(flags, "i")) {
+      options.push(".caseInsensitive")
+    }
+    if (this._removeValueFromArray(flags, "x")) {
+      options.push(".allowCommentsAndWhitespace")
+    }
+    if (this._removeValueFromArray(flags, "s")) {
+      options.push(".dotMatchesLineSeparators")
+    }
+    var formattedOptions = ""
+    if (options.length == 1) {
+      formattedOptions += ", options: "
+      formattedOptions += options[0]
+    } else if (options.length > 1) {
+      formattedOptions += ", options: ["
+      formattedOptions += options.join(", ")
+      formattedOptions += "]"
+    }
 
     // Generate code string
     codeString.append(`import Foundation`)
     codeString.append()
     codeString.append(`let pattern = ${this._escapeSwiftString(regex.toString())}`)
-    codeString.append(`let regex = try! NSRegularExpression(pattern: pattern, options: ` + (includesXFlag ? `.anchorsMatchLines` : `[]`) + `)`)
+    codeString.append(`let regex = try! NSRegularExpression(pattern: pattern${formattedOptions})`)
     codeString.append(`let testString = ${this._escapeSwiftString(testString)}`)
     codeString.append(`let stringRange = NSRange(location: 0, length: testString.utf16.count)`)
 

--- a/Swift5_2.js
+++ b/Swift5_2.js
@@ -97,6 +97,43 @@ class Swift5_2 extends PureComponent {
     // Generate code string
     codeString.append(`import Foundation`)
     codeString.append()
+
+    if (flags.length > 0) {
+      // Show notes to the user if they included an unsupported flag
+      if (flags.indexOf("X") > -1) {
+        codeString.append(`// WARNING: You included a flag that Swift doesn't support: X`)
+        codeString.append(`//          When this flag is set, it causes any backslash in the pattern that is followed by a letter that has no special meaning to cause an error.`)
+        codeString.append(`//          By default in Swift, a backslash followed by a letter with no special meaning will be treated as a literal.`)
+      }
+      if (flags.indexOf("u") > -1) {
+        codeString.append(`// WARNING: You included a flag that Swift doesn't support: u`)
+        codeString.append(`//          When this flag is set, it makes the pattern and subject strings to be treated as unicode.`)
+        codeString.append(`//          Swift already treats the pattern and subject strings as unicode by default, so including this flag is redundant.`)
+      }
+      if (flags.indexOf("J") > -1) {
+        codeString.append(`// WARNING: You included a flag that Swift doesn't support: J`)
+        codeString.append(`//          Wehn this flag is set, it allows duplicated capturing group names.`)
+        codeString.append(`//          By default, Swift captures only the last value matched for a repeated capture group.`)
+        codeString.append(`//          As an alternative, the pattern can be modified to contain one capturing group per group you want to get in the result.`)
+      }
+      if (flags.indexOf("A") > -1) {
+        codeString.append(`// WARNING: You included a flag that Swift doesn't support: A`)
+        codeString.append(`//          When this flag is set, it causes the pattern to be "anchored", that is, it is constrained to match only at the start of the string which is being searched (the "subject string").`)
+        codeString.append(`//          As an alternative, this effect can also be achieved by appropriate constructs in the pattern itself.`)
+      }
+      if (flags.indexOf("U") > -1) {
+        codeString.append(`// WARNING: You included a flag that Swift doesn't support: U`)
+        codeString.append(`//          When this flag is set, it inverts the "greediness" of the quantifiers so that they are not greedy by default, but become greedy if followed by '?'.`)
+        codeString.append(`//          As an alternative, this effect can also be achieved by setting a (?U) modifier setting within the pattern or by a question mark behind a quantifier (e.g. .*?).`)
+      }
+      if (flags.indexOf("D") > -1) {
+        codeString.append(`// WARNING: You included a flag that Swift doesn't support: D`)
+        codeString.append(`//          When this flag is set, it forces the a dollar sign ('$'), to always match end of the string, instead of end of the line. This option is ignored if the 'm' flag is set.`)
+        codeString.append(`//          There's no equivalent implementation of this flag in Swift, but you may want to check the 'm' flag instead.`)
+      }
+      codeString.append()
+    }
+
     codeString.append(`let pattern = ${this._escapeSwiftString(regex.toString())}`)
     codeString.append(`let regex = try! NSRegularExpression(pattern: pattern${formattedOptions})`)
     codeString.append(`let testString = ${this._escapeSwiftString(testString)}`)


### PR DESCRIPTION
## Summary

This PR adds a new Swift Code Generator that uses Swift 5.2.
Resolves #1368

## Tests

<details><summary>Click to see the tests results</summary>
<p>

## isSubtituting = true, isGlobal = true

Pattern: `(http[s]?(\S*))(.*)`

Substitution String: `[$1]($1?ref=rogeroba)$3`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

let pattern = #"(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: [])
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
let substitutionString = #"[$1]($1?ref=rogeroba)$3"#
let result = regex.stringByReplacingMatches(in: testString, range: stringRange, withTemplate: substitutionString)
print(result)
```

</p>
</details>

<details><summary>Swift Script Execution Result</summary>
<p>

```
Sample markdown string that contains a link: [http://github.com/rogerluan/](http://github.com/rogerluan/?ref=rogeroba)

*GitHub Profile*

1. [https://github.com/rogerluan/](https://github.com/rogerluan/?ref=rogeroba) - This is my profile

[https://twitter.com/rogerluan_](https://twitter.com/rogerluan_?ref=rogeroba)
```

</p>
</details>

## isSubtituting = true, isGlobal = false

Pattern: `(http[s]?(\S*))(.*)`

Substitution String: `[$1]($1?ref=rogeroba)$3`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

let pattern = #"(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: [])
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
let substitutionString = #"[$1]($1?ref=rogeroba)$3"#
let lookupRange = (testString as NSString).range(of: pattern, options: .regularExpression, range: stringRange)
if lookupRange.intersection(stringRange) != nil {
    let result = regex.stringByReplacingMatches(in: testString, range: lookupRange, withTemplate: substitutionString)
    print(result)
} else {
    print("No matches were found.")
}
```

</p>
</details>

<details><summary>Swift Script Execution Result</summary>
<p>

```
Sample markdown string that contains a link: [http://github.com/rogerluan/](http://github.com/rogerluan/?ref=rogeroba)

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
```

</p>
</details>

## isSubtituting = false, isGlobal = true

Pattern: `(http[s]?(\S*))(.*)`

Substitution String: `[$1]($1?ref=rogeroba)$3`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

let pattern = #"(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: [])
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
let matches = regex.matches(in: testString, range: stringRange)
var result: [[String]] = []
for match in matches {
    var groups: [String] = []
    for rangeIndex in 1 ..< match.numberOfRanges {
        groups.append((testString as NSString).substring(with: match.range(at: rangeIndex)))
    }
    if !groups.isEmpty {
        result.append(groups)
    }
}
print(result)
```

</p>
</details>

<details><summary>Swift Script Execution Result</summary>
<p>

```
[["http://github.com/rogerluan/", "://github.com/rogerluan/", ""], ["https://github.com/rogerluan/", "://github.com/rogerluan/", " - This is my profile"], ["https://twitter.com/rogerluan_", "://twitter.com/rogerluan_", ""]]
```

</p>
</details>

## isSubtituting = false, isGlobal = false

Pattern: `(http[s]?(\S*))(.*)`

Substitution String: `[$1]($1?ref=rogeroba)$3`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

let pattern = #"(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: [])
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
if let firstMatch = regex.firstMatch(in: testString, range: stringRange) {
    let result: [String] = (1 ..< firstMatch.numberOfRanges).map { (testString as NSString).substring(with: firstMatch.range(at: $0)) }
    print(result)
} else {
    print("No matches were found.")
}
```

</p>
</details>

<details><summary>Swift Script Execution Result</summary>
<p>

```
["http://github.com/rogerluan/", "://github.com/rogerluan/", ""]
```

</p>
</details>

## isSubtituting = true, isGlobal = true, includes "x" flag

Pattern: `^(http[s]?(\S*))(.*)`

Substitution String: `[$1]($1?ref=rogeroba)$3`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

let pattern = #"^(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
let substitutionString = #"[$1]($1?ref=rogeroba)$3"#
let result = regex.stringByReplacingMatches(in: testString, range: stringRange, withTemplate: substitutionString)
print(result)
```

</p>
</details>

<details><summary>Swift Script Execution Result</summary>
<p>

```
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

[https://twitter.com/rogerluan_](https://twitter.com/rogerluan_?ref=rogeroba)
```

</p>
</details>

## isSubtituting = true, isGlobal = true, doesn't include "x" flag

Pattern: `^(http[s]?(\S*))(.*)`

Substitution String: `[$1]($1?ref=rogeroba)$3`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

let pattern = #"^(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: [])
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
let substitutionString = #"[$1]($1?ref=rogeroba)$3"#
let result = regex.stringByReplacingMatches(in: testString, range: stringRange, withTemplate: substitutionString)
print(result)
```

</p>
</details>

<details><summary>Swift Script Execution Result</summary>
<p>

```
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
```

</p>
</details>

## Test using all flags

Tested using: `const flags = ["g", "m", "i", "x", "s", "X", "u", "J", "A", "U", "D"]`

<details><summary>Swift Output</summary>
<p>

```swift
import Foundation

// WARNING: You included a flag that Swift doesn't support: X
//          When this flag is set, it causes any backslash in the pattern that is followed by a letter that has no special meaning to cause an error.
//          By default in Swift, a backslash followed by a letter with no special meaning will be treated as a literal.
// WARNING: You included a flag that Swift doesn't support: u
//          When this flag is set, it makes the pattern and subject strings to be treated as unicode.
//          Swift already treats the pattern and subject strings as unicode by default, so including this flag is redundant.
// WARNING: You included a flag that Swift doesn't support: J
//          Wehn this flag is set, it allows duplicated capturing group names.
//          By default, Swift captures only the last value matched for a repeated capture group.
//          As an alternative, the pattern can be modified to contain one capturing group per group you want to get in the result.
// WARNING: You included a flag that Swift doesn't support: A
//          When this flag is set, it causes the pattern to be "anchored", that is, it is constrained to match only at the start of the string which is being searched (the "subject string").
//          As an alternative, this effect can also be achieved by appropriate constructs in the pattern itself.
// WARNING: You included a flag that Swift doesn't support: U
//          When this flag is set, it inverts the "greediness" of the quantifiers so that they are not greedy by default, but become greedy if followed by '?'.
//          As an alternative, this effect can also be achieved by setting a (?U) modifier setting within the pattern or by a question mark behind a quantifier (e.g. .*?).
// WARNING: You included a flag that Swift doesn't support: D
//          When this flag is set, it forces the a dollar sign ('$'), to always match end of the string, instead of end of the line. This option is ignored if the 'm' flag is set.
//          There's no equivalent implementation of this flag in Swift, but you may want to check the 'm' flag instead.

let pattern = #"^(http[s]?(\S*))(.*)"#
let regex = try! NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines, .caseInsensitive, .allowCommentsAndWhitespace, .dotMatchesLineSeparators])
let testString = #"""
Sample markdown string that contains a link: http://github.com/rogerluan/

*GitHub Profile*

1. https://github.com/rogerluan/ - This is my profile

https://twitter.com/rogerluan_
"""#
let stringRange = NSRange(location: 0, length: testString.utf16.count)
let substitutionString = #"[$1]($1?ref=rogeroba)$3"#
let result = regex.stringByReplacingMatches(in: testString, range: stringRange, withTemplate: substitutionString)
print(result)
```

</p>
</details>

As you can see, I added warning comments when the user attempts to use unsupported flags, with some helpful explanation, default behavior, and alternatives.

</p>
</details>

## Design Decisions

- I opted to not add redundant trailing semicolons. Let me know if this is not desired and I can change this style.
- I didn't implement support to all the custom flags, because some of them are not supported by Swift's `NSRegularExpression`.
  - Supported flags: `g`, `m`, `i`, `x`, `s`.
  - Unsupported flags: `X`, `u`, `J`, `A`, `U`, `D` - when a user attempts to use an unsupported flag, a warning will be put in the Swift code output, as you can observe in the tests shown above.

## Next Steps

There're some questions I had that I couldn't figure out on my own.

1. What is the `delimiter` constant, and what should I use it for? I didn't see any use for it in my examples, but maybe it's because I don't understand it.
2. Since there's no test suite, I tested everything by hardcoding consts in the script. The regex const crashes on `_escapeSwiftString(input)` because it's not a String. I can't express the regex const as a String because then some components can't be escaped (e.g. `\S` in my examples). To work around this, I added a `if (input.match(/^\/(.*)\/$/g)) input = input.slice(1, -1)` (remove leading and trailing `/`) while testing. Not sure if this code needs to be present in the production version of the script, because I'm uncertain about the type of the `regex` prop in production 🤔 

## Feedback

Using the `CodeString` indentation was quite confusing 😅 Initially I thought we had to specify the indentation in "level" rather than "number of spaces", so I replaced 1 with 4, 2 with 8, etc. I also thought that the specified indentation would be used in that very same line, and actually it is used only on the next line onwards (so we have to add the indentation a line before, e.g. when opening `{`).

This is quite confusing, and the end result is extremely hard to be read. I'd much rather do e.g.:

```js
codeString.append(`let matches = regex.matches(in: testString, range: stringRange)`)
codeString.append(`var result: [[String]] = []`)
codeString.append(`for match in matches {`)
codeString.append(`    var groups: [String] = []`)
codeString.append(`    for rangeIndex in 1 ..< match.numberOfRanges {`)
codeString.append(`        groups.append((testString as NSString).substring(with: match.range(at: rangeIndex)))`)
codeString.append(`    }`)
codeString.append(`    if !groups.isEmpty {`)
codeString.append(`        result.append(groups)`)
codeString.append(`    }`)
codeString.append(`}`)
codeString.append(`print(result)`)
```

Than:

```js
codeString.append(`let matches = regex.matches(in: testString, range: stringRange)`)
codeString.append(`var result: [[String]] = []`)
codeString.append(`for match in matches {`, 4)
codeString.append(`var groups: [String] = []`)
codeString.append(`for rangeIndex in 1 ..< match.numberOfRanges {`, 8)
codeString.append(`groups.append((testString as NSString).substring(with: match.range(at: rangeIndex)))`, 4)
codeString.append(`}`)
codeString.append(`if !groups.isEmpty {`, 8)
codeString.append(`result.append(groups)`, 4)
codeString.append(`}`, 0)
codeString.append(`}`)
codeString.append(`print(result)`)
```

As the first option is way easier to be read imo 🙇 But, ultimately, maybe using full multiline string literals would be even more readable.
Anyways, just a quick feedback about the API :) I still sticked to using the `CodeString` as designed , because I believe that's how you'd rather see this file.